### PR TITLE
Some minor css changes to Gnome Shell

### DIFF
--- a/gnome-shell/gnome-shell.css
+++ b/gnome-shell/gnome-shell.css
@@ -1248,14 +1248,6 @@ StScrollBar {
 	border-radius: 4px;
 }
 
-.app-well-app:hover .overview-icon, .app-well-app:focus .overview-icon, .app-well-app:selected .overview-icon,
-.app-well-app.app-folder:hover .overview-icon {
-	/* added hover indicator */
-	background-color: transparent;
-	border: 1px solid rgba(255,255,255,1);
-	border-radius: 4px;
-}
-
 .app-well-app.app-folder:focus .overview-icon,
 .app-well-app.app-folder:selected .overview-icon,
 .show-apps:hover .overview-icon,

--- a/gnome-shell/gnome-shell.css
+++ b/gnome-shell/gnome-shell.css
@@ -629,10 +629,6 @@ StScrollBar {
 			-st-icon-style: symbolic;
 			margin-left: 4px;
 			margin-right: 4px; }
-		#panel .panel-button:hover,#panel .panel-button:overview:hover {
-			color: gray;
-			text-shadow:none;
-			icon-shadow:none;	}
 		#panel .panel-button:active, #panel .panel-button:overview, #panel .panel-button:focus, #panel .panel-button:checked {
 			background-color: rgba(0,0,0,0.95);
 			box-shadow: none;

--- a/gnome-shell/gnome-shell.css
+++ b/gnome-shell/gnome-shell.css
@@ -1136,7 +1136,7 @@ StScrollBar {
 	background-gradient-direction: horizontal;
 	background-gradient-start: rgba(140,140,140,0.7);
 	background-gradient-end: rgba(180,180,180,0.7);
-	border-color: rgba(100,100,100,0.8);
+  border-color: rgba(100,100,100,0.8);
 	box-shadow: 0;
 	padding: 0 0;
 }
@@ -1162,8 +1162,8 @@ StScrollBar {
 	border-radius: 4px;
 	padding: 4px 12px;
 	color: black;
-	border: solid 1px gray;
-	background-color: rgba(255,255,255,0.98);
+  background-color: rgba(220, 220, 220, 0.9);
+  box-shadow: 0 0px 3px 0 rgba(25,25,25,0.5);
 	text-align: center;
 	-x-offset: 8px;
 }

--- a/gnome-shell/gnome-shell.css
+++ b/gnome-shell/gnome-shell.css
@@ -595,11 +595,10 @@ StScrollBar {
 /* TOP BAR */
 #panel {
 	font-weight: normal;
-	font-size: 90%;
 	color: black;
 	height: 24px;
 	background-color: rgba(255,255,255,0.75);
-	box-shadow: 0px 1px 3px 1px rgba(0,0,0,0.5);
+	box-shadow: 0px 1px 2px 1px rgba(0,0,0,0.3);
 	text-shadow: none;
 }
 	#panel.unlock-screen, #panel.login-screen, #panel.lock-screen {


### PR DESCRIPTION
- Modified top bar
   -  Increased font size slightly. the 90% font size made the text look like it had very low resolution on some screens, and I did not see any reason to why it should be smaller than the standard.
   -  Reduced box shadow. This is just my opinion, but I think there was way too much shadow beneath the top bar.
   -  Removed hover effect for icons on top bar. It did not look good, and it is not how it is in macOS Sierra.

- Removed hover indicating border on app icons in dock
   -  This is again just a personal preference, but the border used to indicate hovering over applications in the dock was not aesthetically well designed, nor was it necessary. When hovering over an application a label is shown anyway, so there is no need to have a misplaced gray border around the app icon as well. There isn't any hover effect in the real macOS Sierra either, assuming app icon enlargement is turned off. An option to enlarge app icons upon hovering would be nice, but that is a whole different case.

- Styled dock application labels
  -  Modified the dock application hover labels so that they more closely resemble the ones in macOS Sierra