### PR TITLE
Fix #63: Ugly gnome shell gradient

### DIFF
--- a/gnome-shell/gnome-shell.css
+++ b/gnome-shell/gnome-shell.css
@@ -601,6 +601,8 @@ StScrollBar {
 	box-shadow: 0px 1px 2px 1px rgba(0,0,0,0.3);
 	text-shadow: none;
 }
+	#panel.solid {
+		background-gradient-direction: none; }
 	#panel.unlock-screen, #panel.login-screen, #panel.lock-screen {
 		background-color: transparent; }
 	#panel #panelLeft, #panel #panelCenter {


### PR DESCRIPTION
This fixes #63 for me on Ubuntu 17.10 with GNOME Shell 3.26.2. 
Untested with other versions though.