### PR TITLE
Remove minimum popup menu width

### DIFF
--- a/cinnamon/cinnamon.css
+++ b/cinnamon/cinnamon.css
@@ -188,7 +188,6 @@ StScrollBar StButton#hhandle {
     padding-right: 0px;
     padding-top: 0px;
     padding-bottom: 0px;
-    min-width: 250px;
     min-height: 80px;
     border:rgba(0,0,0,0.8);
     border-radius: 3px;


### PR DESCRIPTION
Fixes #83 's empty space issue

After:
![image](https://user-images.githubusercontent.com/11057934/56079296-76e59a80-5dea-11e9-974c-66957853c7fd.png)
