### PR TITLE
fix cinnamon menu margin (so search box does not abut right edge)

### DIFF
--- a/cinnamon/cinnamon.css
+++ b/cinnamon/cinnamon.css
@@ -189,6 +189,10 @@ StScrollBar StButton#hhandle:active {
   border-bottom: 0px;
 }
 
+.menu {
+  padding-right: 10px;
+}
+
 .menu StEntry,
 .popup-menu StEntry {
   border-image: url("misc-assets/entry.svg") 7;


### PR DESCRIPTION
Yes, minor/trivial but the search box against the right edge is visually annoying 8-(