### PR TITLE
GNOME shell: Darker Looking Glass background

### DIFF
--- a/gnome-shell/gnome-shell.css
+++ b/gnome-shell/gnome-shell.css
@@ -1871,7 +1871,7 @@ StScrollBar {
 		background-color: rgba(255, 255, 255, 0.5); }
 
 #LookingGlassDialog {
-	background-color: rgba(255,255,255,0.95);
+	background-color: rgba(60,60,60,0.9);
 	spacing: 4px;
 	padding: 4px;
 	border: none;


### PR DESCRIPTION
This makes it easier to read the relevant text.

Closes #91 